### PR TITLE
Avoid Error by iterating over Functions

### DIFF
--- a/examples/explore_functions.py
+++ b/examples/explore_functions.py
@@ -6,7 +6,7 @@ with open('token-runtime.evm') as f:
 
 cfg = CFG(runtime_bytecode)
 
-for function in cfg.functions:
+for function in cfg.functions.values():
     print('Function {}'.format(function.name))
     # Each function may have a list of attributes
     # An attribute can be:


### PR DESCRIPTION
Otherwise I get the following error:

```
Traceback (most recent call last):
  File "explore_functions.py", line 10, in <module>
    print('Function {}'.format(function.name))
AttributeError: 'int' object has no attribute 'name'
```

Happy Holidays from ChainSecurity. :christmas_tree: 